### PR TITLE
Fix token sampling underflow for short token datasets

### DIFF
--- a/training/train_large.m
+++ b/training/train_large.m
@@ -278,6 +278,12 @@ int main(int argc, char *argv[]) {
         uint16_t *token_data = (uint16_t*)mmap(NULL, data_len, PROT_READ, MAP_PRIVATE, data_fd, 0);
         if (token_data == MAP_FAILED) { printf("mmap failed\n"); return 1; }
         size_t n_tokens = data_len / 2;
+        if (n_tokens <= (size_t)(SEQ + 1)) {
+            printf("Token data too short: need at least %d tokens, got %zu\n", SEQ + 2, n_tokens);
+            munmap(token_data, data_len);
+            close(data_fd);
+            return 1;
+        }
         printf("Token data: %zu tokens (%.1f MB)\n", n_tokens, data_len/1e6);
 
         // Gradient buffers shared across layers (reused each step)


### PR DESCRIPTION
## Summary
- add a dataset length guard after `mmap` in `train_large.m`
- prevent `size_t` underflow in `max_pos = n_tokens - SEQ - 1`
- return early with a clear error when the token file is too short for one training window

## Why
`max_pos` is computed from unsigned `size_t`. If `n_tokens <= SEQ + 1`, the subtraction wraps to a huge value, which can produce invalid random offsets and out-of-bounds reads.

## Validation
- built successfully with `make train_large` in `training/`
