### PR TITLE
Fix hardcoded TinyStories data path in train_large/train_large_ane

### DIFF
--- a/training/README.md
+++ b/training/README.md
@@ -87,11 +87,13 @@ Downloads pretokenized TinyStories (Llama 2 BPE, 32K vocab) from HuggingFace. Pr
 make train_large
 ./train_large stories110M.bin 256 100 1e-4
 ./train_large --model stories110M.bin --steps 100 --lr 1e-4
+./train_large --data ./tinystories_data00.bin --steps 100 --lr 1e-4
 
 # PR#19: ANE-offloaded classifier + softmax + rmsnorm_bwd
 make train_large_ane
 ./train_large_ane stories110M.bin 256 100 1e-4
 ./train_large_ane --no-ane-extras --steps 100    # disable ANE extras
+./train_large_ane --data ./tinystories_data00.bin --steps 100 --lr 1e-4
 
 # Dynamic pipeline (no recompilation)
 cd training_dynamic && make train
@@ -100,10 +102,11 @@ cd training_dynamic && make train
 ./train --steps 200 --lr 1e-4  # custom steps/lr
 ```
 
-**CLI flags (all pipelines):**
+**CLI flags (`train_large` / `train_large_ane`):**
 - `--steps N` (default 10000)
 - `--lr F` (default 3e-4)
 - `--model PATH` — pretrained weights file
+- `--data PATH` — tokenized TinyStories `.bin` file (default: `tinystories_data00.bin`)
 - `--ckpt PATH` — checkpoint file (preserved across exec() restarts)
 - `--resume` — resume from checkpoint
 - `--no-ane-extras` — (train_large_ane only) disable ANE classifier/softmax/rmsnorm_bwd

--- a/training/train_large.m
+++ b/training/train_large.m
@@ -7,7 +7,7 @@
 
 #define CKPT_PATH_DEFAULT "ane_stories110M_ckpt.bin"
 #define MODEL_PATH_DEFAULT "stories110M.bin"
-#define DATA_PATH "tinystories_data00.bin"
+#define DATA_PATH_DEFAULT "tinystories_data00.bin"
 
 // ===== Weight loading from llama2.c format =====
 static bool load_pretrained(LayerWeights *lw, float *rms_final, float *embed, const char *path) {
@@ -195,6 +195,7 @@ int main(int argc, char *argv[]) {
         // Parse args
         const char *ckpt_path = CKPT_PATH_DEFAULT;
         const char *model_path = MODEL_PATH_DEFAULT;
+        const char *data_path = DATA_PATH_DEFAULT;
         bool do_resume = false;
         int pos = 0;
         for (int i=1; i<argc; i++) {
@@ -203,6 +204,7 @@ int main(int argc, char *argv[]) {
             else if (strcmp(argv[i], "--lr") == 0 && i+1<argc) lr = atof(argv[++i]);
             else if (strcmp(argv[i], "--ckpt") == 0 && i+1<argc) ckpt_path = argv[++i];
             else if (strcmp(argv[i], "--model") == 0 && i+1<argc) model_path = argv[++i];
+            else if (strcmp(argv[i], "--data") == 0 && i+1<argc) data_path = argv[++i];
             else if (argv[i][0] != '-') {
                 if (pos == 0) model_path = argv[i];
                 else if (pos == 1) { /* seq - compile-time constant */ }
@@ -283,8 +285,12 @@ int main(int argc, char *argv[]) {
         }
 
         // mmap token data
-        int data_fd = open(DATA_PATH, O_RDONLY);
-        if (data_fd < 0) { printf("Cannot open %s\n", DATA_PATH); return 1; }
+        int data_fd = open(data_path, O_RDONLY);
+        if (data_fd < 0) {
+            printf("Cannot open token data: %s\n", data_path);
+            printf("Hint: run `bash download_data.sh` in training/ or pass --data /path/to/tinystories_data00.bin\n");
+            return 1;
+        }
         struct stat st; fstat(data_fd, &st);
         size_t data_len = st.st_size;
         uint16_t *token_data = (uint16_t*)mmap(NULL, data_len, PROT_READ, MAP_PRIVATE, data_fd, 0);
@@ -340,7 +346,7 @@ int main(int argc, char *argv[]) {
                     lw, la, rms_final, &arms_final, embed, &aembed);
                 printf("[exec() restart step %d, %d compiles, loss=%.4f]\n", step, g_compile_count, last_loss);
                 fflush(stdout);
-                execl(argv[0], argv[0], "--resume", "--ckpt", ckpt_path, NULL);
+                execl(argv[0], argv[0], "--resume", "--ckpt", ckpt_path, "--data", data_path, NULL);
                 perror("execl"); return 1;
             }
 

--- a/training/train_large_ane.m
+++ b/training/train_large_ane.m
@@ -9,7 +9,7 @@
 //               NLL loss + gradient (needs target indexing)
 //
 // Build: make train_large_ane
-// Run:   ./train_large_ane [--resume] [--steps N] [--lr F]
+// Run:   ./train_large_ane [--resume] [--steps N] [--lr F] [--data PATH]
 #include "stories_io.h"
 #include "stories_mil.h"
 #include "stories_cpu_ops.h"
@@ -18,7 +18,7 @@
 
 #define CKPT_PATH_DEFAULT "ane_stories110M_ckpt.bin"
 #define MODEL_PATH_DEFAULT "stories110M.bin"
-#define DATA_PATH "tinystories_data00.bin"
+#define DATA_PATH_DEFAULT "tinystories_data00.bin"
 
 // ===== Weight loading from llama2.c format =====
 static bool load_pretrained(LayerWeights *lw, float *rms_final, float *embed, const char *path) {
@@ -204,6 +204,7 @@ int main(int argc, char *argv[]) {
         int adam_t = 0, start_step = 0;
         const char *ckpt_path = CKPT_PATH_DEFAULT;
         const char *model_path = MODEL_PATH_DEFAULT;
+        const char *data_path = DATA_PATH_DEFAULT;
         bool do_resume = false;
         bool ane_extras = true;  // classifier, softmax, rmsnorm_bwd on ANE
         int pos = 0;
@@ -214,6 +215,7 @@ int main(int argc, char *argv[]) {
             else if (strcmp(argv[i], "--lr") == 0 && i+1<argc) lr = atof(argv[++i]);
             else if (strcmp(argv[i], "--ckpt") == 0 && i+1<argc) ckpt_path = argv[++i];
             else if (strcmp(argv[i], "--model") == 0 && i+1<argc) model_path = argv[++i];
+            else if (strcmp(argv[i], "--data") == 0 && i+1<argc) data_path = argv[++i];
             else if (argv[i][0] != '-') {
                 if (pos == 0) model_path = argv[i];
                 else if (pos == 1) { /* seq - compile-time constant */ }
@@ -271,8 +273,12 @@ int main(int argc, char *argv[]) {
         }
 
         // mmap token data
-        int data_fd = open(DATA_PATH, O_RDONLY);
-        if (data_fd < 0) { printf("Cannot open %s\n", DATA_PATH); return 1; }
+        int data_fd = open(data_path, O_RDONLY);
+        if (data_fd < 0) {
+            printf("Cannot open token data: %s\n", data_path);
+            printf("Hint: run `bash download_data.sh` in training/ or pass --data /path/to/tinystories_data00.bin\n");
+            return 1;
+        }
         struct stat st; fstat(data_fd, &st);
         size_t data_len = st.st_size;
         uint16_t *token_data = (uint16_t*)mmap(NULL, data_len, PROT_READ, MAP_PRIVATE, data_fd, 0);
@@ -354,9 +360,9 @@ int main(int argc, char *argv[]) {
                 printf("[exec() restart step %d, %d compiles, loss=%.4f]\n", step, g_compile_count, last_loss);
                 fflush(stdout);
                 if (ane_extras)
-                    execl(argv[0], argv[0], "--resume", "--ckpt", ckpt_path, NULL);
+                    execl(argv[0], argv[0], "--resume", "--ckpt", ckpt_path, "--data", data_path, NULL);
                 else
-                    execl(argv[0], argv[0], "--resume", "--ckpt", ckpt_path, "--no-ane-extras", NULL);
+                    execl(argv[0], argv[0], "--resume", "--ckpt", ckpt_path, "--data", data_path, "--no-ane-extras", NULL);
                 perror("execl"); return 1;
             }
 


### PR DESCRIPTION
## Why I worked on this

First, thank you for building this project. ANE is honestly awesome, and I’m actively using it in real workflows.

I’m running these training pipelines as part of my Open Claw agent environment across multiple Apple machines and different launch contexts (manual runs, scripted runs, and restart-driven runs). In that setup, I kept hitting the same issue: the static trainers expected token data at a fixed path.

The run would work in one context, then break in another, and it could also fail after `exec()` restart because the path context was not explicit. That created unnecessary friction for real usage and for onboarding other people.

## What this PR changes

- Adds `--data PATH` to `train_large` and `train_large_ane`
- Replaces hardcoded token data path with a runtime-configurable path
- Preserves `--data` across `exec()` restart so resumed training keeps the same dataset
- Improves missing-data error text with clear next steps
- Updates `training/README.md` with examples and flag documentation

## Why this helps the community

- Makes the project easier to run from any working directory
- Supports custom dataset locations without source edits
- Prevents restart-related path regressions
- Reduces first-run setup failures for new contributors
- Improves compatibility with scripted/automated setups

## Validation

I validated this on Apple Silicon macOS with explicit absolute paths:

- `train_large --steps 11 --data <abs-path>` (forces restart path)
- `train_large_ane --no-ane-extras --steps 11 --data <abs-path>` (same restart validation)
- Missing-path negative check confirms clear error guidance

Both restart paths resumed correctly and continued reading token data as expected.

## Personal note

I’m very excited about this project and would love to keep contributing to its growth. I’ve contributed multiple times to Open Claw, and I’m using ANE in serious, practical workflows, so I plan to keep sending real-world fixes and useful benchmark data upstream.
