### PR TITLE
Fix docs: add training data download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Key optimizations:
     └── Makefile
 ```
 
+## Training Data
+
+Training requires pretokenized TinyStories data. To download:
+```bash
+cd training && bash download_data.sh
+```
+See [training/README.md](training/README.md) for detailed training instructions.
+
 ## Building
 
 Requires macOS 15+ on Apple Silicon (tested on M4).


### PR DESCRIPTION
Fixes #4 and #10. Adds a Training Data section to the main README that references the download_data.sh script and training/README.md for detailed instructions.