### PR TITLE
Guard short token datasets in ANE and dynamic training paths

### DIFF
--- a/training/train_large_ane.m
+++ b/training/train_large_ane.m
@@ -284,6 +284,12 @@ int main(int argc, char *argv[]) {
         uint16_t *token_data = (uint16_t*)mmap(NULL, data_len, PROT_READ, MAP_PRIVATE, data_fd, 0);
         if (token_data == MAP_FAILED) { printf("mmap failed\n"); return 1; }
         size_t n_tokens = data_len / 2;
+        if (n_tokens <= (size_t)(SEQ + 1)) {
+            printf("Token data too short: need at least %d tokens, got %zu\n", SEQ + 2, n_tokens);
+            munmap(token_data, data_len);
+            close(data_fd);
+            return 1;
+        }
         printf("Token data: %zu tokens (%.1f MB)\n", n_tokens, data_len/1e6);
 
         // Gradient buffers

--- a/training/training_dynamic/train.m
+++ b/training/training_dynamic/train.m
@@ -340,6 +340,12 @@ int main(int argc, char *argv[]) {
         uint16_t *token_data = (uint16_t*)mmap(NULL, data_len, PROT_READ, MAP_PRIVATE, data_fd, 0);
         if (token_data == MAP_FAILED) { printf("mmap failed\n"); return 1; }
         size_t n_tokens = data_len / 2;
+        if (n_tokens <= (size_t)(SEQ + 1)) {
+            printf("Token data too short: need at least %d tokens, got %zu\n", SEQ + 2, n_tokens);
+            munmap(token_data, data_len);
+            close(data_fd);
+            return 1;
+        }
         printf("Token data: %zu tokens (%.1f MB)\n", n_tokens, data_len/1e6);
 
         // Vocab compaction: map 32K sparse vocab → ~9K compact


### PR DESCRIPTION
## Summary
- add a token dataset length guard in `training/train_large_ane.m`
- add the same guard in `training/training_dynamic/train.m`
- fail early with a clear error when the dataset is too short for one `(input,target)` training window

## Why
Both paths sample with:

`max_pos = n_tokens - SEQ - 1`

When `n_tokens <= SEQ + 1`, this unsigned subtraction can underflow, producing a huge random range and potentially leading to out-of-bounds reads.

## Validation
- `make -C training train_large_ane`
- `make -C training/training_dynamic train`
